### PR TITLE
items#updateでtitleとbodyに加え、author_idも含めて内容を更新できるようにしました。

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -13,7 +13,7 @@ class AuthorsController < ApplicationController
      def create
           author = Author.new(name: params[:name])
           if author.save then
-               render :json => {result: "success", name: paramas[:name]}
+               render :json => {result: "success", name: params[:name]}
           else 
                render :json => {result: "failed"}
           end
@@ -25,8 +25,9 @@ class AuthorsController < ApplicationController
      end
 
      def update
-          author = Author.find_by(params[:id])
+          author = Author.find_by(id: params[:id])
           author.update(name: params[:name])
+          author.save
           render :json => author
      end
 

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -27,7 +27,6 @@ class AuthorsController < ApplicationController
      def update
           author = Author.find_by(id: params[:id])
           author.update(name: params[:name])
-          author.save
           render :json => author
      end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
      def index          
-          @item = Item.all
+          item = Item.all
           items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
          render  :json =>  items
      end
@@ -11,42 +11,24 @@ class ItemsController < ApplicationController
      end
 
      def create 
-          item = Item.new(title: params[:title], body: params[:body], )
-         if item.save then
-          render :json => { name: params[:name]}
+          item = Item.new(title: params[:title], body: params[:body])
+          if item.save then
+          render :json => { result: "success", title: item.title, body: item.body}
          else
           render :json => { result:  "failed", title: item.title,  body: item.body}
          end
      end
 
-
      def update
-          #アップデートしたいitemsのデータをidから取得
-          #authorの
-          #のnameを含めてupdateする
-          #アップデートしたデータのjsonで返す。
           item = Item.find_by(id: params[:id])
-
           if item.update(title: params[:title], body: params[:body], author_id: params[:author_id]) 
-          #author = Author.find(3)
-          #item = Item.find(4)
-          #item.update(title: item.title, body: item.body, author_id: @author.name)
-          awesome_hash = item.attributes
-          awesome_hash.store("name", item.author.name)
-          awesome_hash.store("result", "success")
-          render :json => awesome_hash
+               awesome_hash = item.attributes
+               awesome_hash.store("name", item.author.name)
+               awesome_hash.store("result", "success")
+               render :json => awesome_hash
           else 
-          render :json => { result:  "failed", title: item.title,  body: item.body}
-
-          #render :json => item.to_json(methods: [:author])
-          #https://qiita.com/eggc/items/29a3c9a41d77227fb10a
-
-          #{title: item.title, body: item.body, name: item.author.name}
+               render :json => { result:  "failed", title: item.title,  body: item.body}
           end
-     end
-
-     def awesome_attributes
-          return {}
      end
 
      def destroy
@@ -55,11 +37,3 @@ class ItemsController < ApplicationController
           render :json => item
      end
 end
-
-
-#別々のモデルを関連づけれられるように
-#authorからtitle、body
-#index itemsでtitleとbodyが入るがここにauthorも含める。
-#item updateをする時にauthorのidを指定するとtitle、bodyにauthorも追加される。
-#has many has one ActiveRecord
-#relation

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
      def index          
           item = Item.all
           items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
-         render  :json =>  items
+          render  :json =>  items
      end
 
      def show
@@ -13,10 +13,10 @@ class ItemsController < ApplicationController
      def create 
           item = Item.new(title: params[:title], body: params[:body])
           if item.save then
-          render :json => { result: "success", title: item.title, body: item.body}
-         else
-          render :json => { result:  "failed", title: item.title,  body: item.body}
-         end
+               render :json => { result: "success", title: item.title, body: item.body}
+          else
+               render :json => { result:  "failed", title: item.title,  body: item.body}
+          end
      end
 
      def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
      def index          
-          items = Item.all
+          @item = Item.all
           items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
          render  :json =>  items
      end
@@ -11,9 +11,9 @@ class ItemsController < ApplicationController
      end
 
      def create 
-          item = Item.new(title: params[:title], body: params[:body])
+          item = Item.new(title: params[:title], body: params[:body], )
          if item.save then
-          render :json => { result:  "success", title: item.title,  body: item.body}
+          render :json => { name: params[:name]}
          else
           render :json => { result:  "failed", title: item.title,  body: item.body}
          end
@@ -21,10 +21,32 @@ class ItemsController < ApplicationController
 
 
      def update
+          #アップデートしたいitemsのデータをidから取得
+          #authorの
+          #のnameを含めてupdateする
+          #アップデートしたデータのjsonで返す。
           item = Item.find_by(id: params[:id])
-          item.update(title: params[:title], body: params[:body])
-          item.save
-          render :ison => item
+
+          if item.update(title: params[:title], body: params[:body], author_id: params[:author_id]) 
+          #author = Author.find(3)
+          #item = Item.find(4)
+          #item.update(title: item.title, body: item.body, author_id: @author.name)
+          awesome_hash = item.attributes
+          awesome_hash.store("name", item.author.name)
+          awesome_hash.store("result", "success")
+          render :json => awesome_hash
+          else 
+          render :json => { result:  "failed", title: item.title,  body: item.body}
+
+          #render :json => item.to_json(methods: [:author])
+          #https://qiita.com/eggc/items/29a3c9a41d77227fb10a
+
+          #{title: item.title, body: item.body, name: item.author.name}
+          end
+     end
+
+     def awesome_attributes
+          return {}
      end
 
      def destroy
@@ -33,3 +55,11 @@ class ItemsController < ApplicationController
           render :json => item
      end
 end
+
+
+#別々のモデルを関連づけれられるように
+#authorからtitle、body
+#index itemsでtitleとbodyが入るがここにauthorも含める。
+#item updateをする時にauthorのidを指定するとtitle、bodyにauthorも追加される。
+#has many has one ActiveRecord
+#relation

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,3 +1,3 @@
 class Author < ApplicationRecord
-     validates :name, presence: true
+     has_many :items
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,3 +1,4 @@
 class Author < ApplicationRecord
+     validates :name, presence: true
      has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,5 @@
 class Item < ApplicationRecord
      validates :title, :body, presence: true
+     belongs_to :author
+
 end

--- a/db/migrate/20201213080147_create_items.rb
+++ b/db/migrate/20201213080147_create_items.rb
@@ -1,7 +1,7 @@
 class CreateItems < ActiveRecord::Migration[6.1]
   def change
     create_table :items do |t|
-
+      
       t.timestamps
     end
   end

--- a/db/migrate/20201213101828_add_details_to_items.rb
+++ b/db/migrate/20201213101828_add_details_to_items.rb
@@ -1,6 +1,6 @@
 class AddDetailsToItems < ActiveRecord::Migration[6.1]
   def change
-    add_column :items, :title, :string
+    add_column :items, :title, :string 
     add_column :items, :body, :string
   end
 end

--- a/db/migrate/20201213101828_add_details_to_items.rb
+++ b/db/migrate/20201213101828_add_details_to_items.rb
@@ -1,6 +1,6 @@
 class AddDetailsToItems < ActiveRecord::Migration[6.1]
   def change
-    add_column :items, :title, :string 
+    add_column :items, :title, :string
     add_column :items, :body, :string
   end
 end

--- a/db/migrate/20201221092718_create_authors.rb
+++ b/db/migrate/20201221092718_create_authors.rb
@@ -2,7 +2,6 @@ class CreateAuthors < ActiveRecord::Migration[6.1]
   def change
     create_table :authors do |t|
       t.string :name
-
       t.timestamps
     end
   end

--- a/db/migrate/20201223095307_add_author_id_to_item.rb
+++ b/db/migrate/20201223095307_add_author_id_to_item.rb
@@ -1,0 +1,5 @@
+class AddAuthorIdToItem < ActiveRecord::Migration[6.1]
+  def change
+    add_column :items, :author_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_092718) do
+ActiveRecord::Schema.define(version: 2020_12_23_095307) do
 
   create_table "authors", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_092718) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "title"
     t.string "body"
+    t.integer "author_id"
   end
 
 end


### PR DESCRIPTION
POSTリクエストでitemsのidを選択し、titleキーとbodyキーとauthor_idに任意のバリューを送信すると、idで指定されたitemsのデータがupdateアクションよってリクエストで送られたデータに書き換えられ、jsonで返されます。jsonで返される際には、ハッシュにitem テーブルのauthor_idに紐づいたauthorテーブルのidとそのidに合致するnameキーのバリューも含まれます。
また、if文で上記内容が無事にupdateされた際にはハッシュにresultキーとsuccessというバリューが含まれ、データに不備がある場合はresultキーにfailedというバリューが含まれた状態でjsonで返されます。