### PR TITLE
itemモデルのbelongs_to にoptional:trueを追加しました。

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
      validates :title, :body, presence: true
-     belongs_to :author
+     belongs_to :author, optional: true
 
 end


### PR DESCRIPTION
belongs_ to にoptional:true を追加し、author_idがnullでもcreateできるようにしました。