### PR TITLE
itemsのindexアクション時にハッシュにItemの情報に加えてauthorの名前も含めるようにしました。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,19 @@
 class ItemsController < ApplicationController
      def index          
           items = Item.all
-          items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
+         author = "#{params[:author]}"
+         keyword = "#{params[:keyword]}"
+         if author.present? && keyword.empty?
+          items = Item.left_joins(:author).where(authors: {name: "#{author}"})
+         elsif author.empty? && keyword.present?
+          items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
+         elsif author.present? && keyword.present?
+         items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
+         end
+
+               #items = Item.left_joins(:author).where("name LIKE?", "%#{params[:keyword]}%").present?
+          #else items = Item.all
+          #end
           awesome = []
           items.each do |item|
                hash = item.attributes 
@@ -14,6 +26,7 @@ class ItemsController < ApplicationController
           end
           render :json => awesome
      end
+    # items.to_json(:include => :author)
 
      def show
           item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,18 @@
 class ItemsController < ApplicationController
      def index          
-          item = Item.all
+          items = Item.all
           items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
-          render  :json =>  items
+          awesome = []
+          items.each do |item|
+               hash = item.attributes 
+               awesome.push(hash)
+               if item.author.present?
+                    hash.store("name", item.author.name)
+               else 
+                    hash.store("name", nil)
+               end
+          end
+          render :json => awesome
      end
 
      def show


### PR DESCRIPTION
itemsコントローラのindexアクション時に表示されるハッシュにItemの情報だけでなく、authorの名前を含めるようにしました。
条件分岐も設定し、もしitemに紐づく(従属する）authorのデータがハッシュ内にあればauthorのデータがなければnilと表示されるようにしました。この条件分岐によってauthorデータが含まれていない起きるエラーを回避しています。