### PR TITLE
itemsのindexアクションでauthorの名前で検索できるようにしました。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,9 +11,6 @@ class ItemsController < ApplicationController
          items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
          end
 
-               #items = Item.left_joins(:author).where("name LIKE?", "%#{params[:keyword]}%").present?
-          #else items = Item.all
-          #end
           awesome = []
           items.each do |item|
                hash = item.attributes 
@@ -26,7 +23,6 @@ class ItemsController < ApplicationController
           end
           render :json => awesome
      end
-    # items.to_json(:include => :author)
 
      def show
           item = Item.find(params[:id])


### PR DESCRIPTION
itemsコントローラのindexアクションにて、検索時にauthorキーにauthorのname、keywordキーにtitileもしくはbodyの内容を入力して検索できるようにしました。
下記の条件で結果を変えました。
authorの値があり、keywordの値がない場合は、authorの値が含まれるハッシュを返す。
authorの値がなく、keywordの値がある場合は、keywordの値が含まれるハッシュを返す。
authorの値があり、keywordの値がある場合は、authorの値が含まれ、かつkeywordの値が含まれるハッシュを返す。
