### PR TITLE
Feature/itemsでauthorの名前でも検索できるようにする改

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,9 +11,6 @@ class ItemsController < ApplicationController
          items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
          end
 
-               #items = Item.left_joins(:author).where("name LIKE?", "%#{params[:keyword]}%").present?
-          #else items = Item.all
-          #end
           awesome = []
           items.each do |item|
                hash = item.attributes 
@@ -26,7 +23,6 @@ class ItemsController < ApplicationController
           end
           render :json => awesome
      end
-    # items.to_json(:include => :author)
 
      def show
           item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,15 +1,7 @@
 class ItemsController < ApplicationController
      def index          
           items = Item.all
-         author = "#{params[:author]}"
-         keyword = "#{params[:keyword]}"
-         if author.present? && keyword.empty?
-          items = Item.left_joins(:author).where(authors: {name: "#{author}"})
-         elsif author.empty? && keyword.present?
-          items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
-         elsif author.present? && keyword.present?
-         items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
-         end
+          items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
 
           awesome = []
           items.each do |item|

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,15 @@
 class ItemsController < ApplicationController
      def index          
           items = Item.all
-          items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
+         author = "#{params[:author]}"
+         keyword = "#{params[:keyword]}"
+         if author.present? && keyword.empty?
+          items = Item.left_joins(:author).where(authors: {name: "#{author}"})
+         elsif author.empty? && keyword.present?
+          items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
+         elsif author.present? && keyword.present?
+         items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
+         end
 
           awesome = []
           items.each do |item|


### PR DESCRIPTION
itemsコントローラのindexアクションにて、検索時にauthorキーにauthorのname、keywordキーにtitileもしくはbodyの内容を入力して検索できるようにしました。  
下記の条件で結果を変えました。  
authorの値があり、keywordの値がない場合は、authorの値が含まれるハッシュを返す。  
authorの値がなく、keywordの値がある場合は、keywordの値が含まれるハッシュを返す。  
authorの値があり、keywordの値がある場合は、authorの値が含まれ、かつkeywordの値が含まれるハッシュを返す。