### PR TITLE
indexの検索機能にauthorのnameでの検索機能も追加しました。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,16 @@
 class ItemsController < ApplicationController
      def index          
           item = Item.all
-          items = Item.where("title LIKE ?", "%#{params[:keyword]}%" ).or (Item.where("body LIKE?","%#{params[:keyword]}%"))
-
+          author = "#{params[:author]}"
+          keyword = "#{params[:keyword]}"
+          if author.present? && keyword.empty?
+           items = Item.left_joins(:author).where(authors: {name: "#{author}"})
+          elsif author.empty? && keyword.present?
+           items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
+          elsif author.present? && keyword.present?
+          items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
+          end
+          
           awesome = []
           items.each do |item|
                hash = item.attributes 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,11 @@
 class ItemsController < ApplicationController
      def index          
           item = Item.all
-          author = "#{params[:author]}"
-          keyword = "#{params[:keyword]}"
-          if author.present? && keyword.empty?
-           items = Item.left_joins(:author).where(authors: {name: "#{author}"})
-          elsif author.empty? && keyword.present?
+          author = params[:author]
+          keyword = params[:keyword]
+          if author.present? && keyword.nil?
+           items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" )
+          elsif author.nil? && keyword.present?
            items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
           elsif author.present? && keyword.present?
           items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )


### PR DESCRIPTION
itemsコントローラのindexアクションにて、検索時にauthorキーにauthorのname、keywordキーにtitileもしくはbodyの内容を入力して検索できるようにしました。  
下記の条件で結果を変えました。  
authorの値があり、keywordの値がない場合は、authorの値が含まれるハッシュを返す。  
authorの値がなく、keywordの値がある場合は、keywordの値が含まれるハッシュを返す。  
authorの値があり、keywordの値がある場合は、authorの値が含まれ、かつkeywordの値が含まれるハッシュを返す。

fd7789fで変更を加えました。
・上記の一番目の条件分岐（authorの値があり、keywordの値がない場合は、authorの値が含まれるハッシュを返す。 ）をjoinsでの記載に変更し、部分一致でも検索を行えるようにしました。
・必要のない文字列へ変換するための記述”#{}"を省きました。
・emptyメソッドをnilメソッドへ変化し、変数に対しても処理が行われるようにしました。
・