### PR TITLE
indexにpagination機能を付け加えました。indexの検索機能の条件分岐を訂正しました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,8 @@ group :development do
   gem 'spring'
 end
 
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'will_paginate', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -155,6 +156,7 @@ DEPENDENCIES
   spring
   sqlite3 (~> 1.4)
   tzinfo-data
+  will_paginate (~> 3.1.0)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,17 +1,29 @@
 class ItemsController < ApplicationController
 
      def index          
+          page = 4
           items = Item.all
           author = params[:author]
           keyword = params[:keyword]
-          if author.present? && keyword.nil?
-           items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" )
-          elsif author.nil? && keyword.present?
-           items = Item.where("title LIKE ?", "%#{keyword}%" ).or (Item.where("body LIKE?","%#{keyword}%"))
-          elsif author.present? && keyword.present?
-          items = Item.joins(:author).where("authors.name LIKE ?", "%#{author}%" ).where("title LIKE ?", "%#{keyword}%" )
-          end
+         items = Item.all
 
+          if author.present? && keyword.blank?
+           items = Item.joins(:author)
+           .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+          elsif author.blank? && keyword.present?
+           items = Item
+           .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
+           .or (Item.where("body LIKE?","%#{keyword}%")).paginate(page: params[:page], per_page: page)
+          elsif author.present? && keyword.present?
+          items = Item.joins(:author)
+          .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+          .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
+          .or(Item.where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+          .where("body LIKE ?", "%#{keyword}%" )).paginate(page: params[:page], per_page: page)
+          else 
+               items = Item.paginate(page: params[:page], per_page: page)
+          end
+       
           awesome = []
           items.each do |item|
                hash = item.attributes 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,25 +1,25 @@
 class ItemsController < ApplicationController
 
      def index          
-          page = 4
+          page = 10
           items = Item.all
           author = params[:author]
           keyword = params[:keyword]
-         items = Item.all
+          items = Item.all
 
           if author.present? && keyword.blank?
-           items = Item.joins(:author)
-           .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+               items = Item.joins(:author)
+               .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
           elsif author.blank? && keyword.present?
-           items = Item
-           .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-           .or (Item.where("body LIKE?","%#{keyword}%")).paginate(page: params[:page], per_page: page)
+               items = Item
+               .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
+               .or (Item.where("body LIKE?","%#{keyword}%")).paginate(page: params[:page], per_page: page)
           elsif author.present? && keyword.present?
-          items = Item.joins(:author)
-          .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-          .or(Item.where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("body LIKE ?", "%#{keyword}%" )).paginate(page: params[:page], per_page: page)
+               items = Item.joins(:author)
+               .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+               .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
+               .or(Item.where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
+               .where("body LIKE ?", "%#{keyword}%" )).paginate(page: params[:page], per_page: page)
           else 
                items = Item.paginate(page: params[:page], per_page: page)
           end


### PR DESCRIPTION
will_paginateというGemをインストールし、indexにpaginationを機能を実装しました。
index内のkeywordやauthorというパラメータを与えて検索する機能の条件分岐に間違いがあったので、修正しました。
nilメソッドを使っていたので、authorやkeywordのパラメータに空の文字列("")が与えられた際に処理されませんでした。
空の文字列でもパラメータにnilが与えられても処理されるようにblankメソッドに書き換えました。
また、keywordとauthorのどちらにもパラメータが与えられなかった場合の処理の記載がなかったので、elseで追記しました。