### PR TITLE
indexの検索機能の条件分岐を減らし、見やすくしました。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,29 +1,19 @@
 class ItemsController < ApplicationController
 
      def index          
-          page = 4
+          page = 10
           items = Item.all
           author = params[:author]
           keyword = params[:keyword]
-         items = Item.all
 
-          if author.present? && keyword.blank?
-           items = Item.joins(:author)
-           .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          elsif author.blank? && keyword.present?
-           items = Item
-           .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-           .or (Item.where("body LIKE?","%#{keyword}%")).paginate(page: params[:page], per_page: page)
-          elsif author.present? && keyword.present?
-          items = Item.joins(:author)
-          .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-          .or(Item.where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("body LIKE ?", "%#{keyword}%" )).paginate(page: params[:page], per_page: page)
-          else 
-               items = Item.paginate(page: params[:page], per_page: page)
+          if author.present? 
+               items = items.joins(:author).where("authors.name LIKE ?", "%#{author}%" )
           end
-       
+          if keyword.present?
+               items = items.where("title LIKE ?", "%#{keyword}%" ).or (items.where("body LIKE?","%#{keyword}%"))
+          end
+          items = items.paginate(page: params[:page], per_page: page)
+
           awesome = []
           items.each do |item|
                hash = item.attributes 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,29 +1,19 @@
 class ItemsController < ApplicationController
 
      def index          
-          page = 4
+          page = 10
           items = Item.all
           author = params[:author]
           keyword = params[:keyword]
-         items = Item.all
 
-          if author.present? && keyword.blank?
-           items = Item.joins(:author)
-           .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          elsif author.blank? && keyword.present?
-           items = Item
-           .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-           .or (Item.where("body LIKE?","%#{keyword}%")).paginate(page: params[:page], per_page: page)
-          elsif author.present? && keyword.present?
-          items = Item.joins(:author)
-          .where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("title LIKE ?", "%#{keyword}%" ).paginate(page: params[:page], per_page: page)
-          .or(Item.where("authors.name LIKE ?", "%#{author}%" ).paginate(page: params[:page], per_page: page)
-          .where("body LIKE ?", "%#{keyword}%" )).paginate(page: params[:page], per_page: page)
-          else 
-               items = Item.paginate(page: params[:page], per_page: page)
+          if author.present? 
+               items = items.joins(:author).where("authors.name LIKE ?", "%#{author}%" )
           end
-       
+          if keyword.present?
+               items = items.where("title LIKE ?", "%#{keyword}%" ).or (items.where("body LIKE?","%#{keyword}%"))
+          end
+               items = items.paginate(page: params[:page], per_page: page)
+               
           awesome = []
           items.each do |item|
                hash = item.attributes 


### PR DESCRIPTION
indexの検索機能の条件分岐において、全てのパターンを一つずつ記載すると記述の量が膨大でした。
authorのパラメータが与えられた時にはauthorをauthors.nameから検索する処理と
keywordのパラメータが与えられた時にはkeywordをitemsのtitleかbodyから検索する処理と
indexが実行された時は条件に関係なくページネーションが実行されるという処理を記述することで、シンプルにしました。